### PR TITLE
[WIP] Add binary serializer for cheezy path

### DIFF
--- a/src/com/team254/lib/trajectory/io/BinaryDeserializer.java
+++ b/src/com/team254/lib/trajectory/io/BinaryDeserializer.java
@@ -1,0 +1,57 @@
+package com.team254.lib.trajectory.io;
+
+import com.team254.lib.trajectory.Path;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import com.team254.lib.trajectory.Trajectory;
+
+/**
+ * Deserializes a binary file to a Path
+ * 
+ * @author mstojcevich
+ */
+public class BinaryDeserializer {
+
+	public Path deserialize(DataInputStream serialized) throws IOException {
+		// Read in the name (keep reading in chars until we reach a null-terminator
+		StringBuilder nameBuilder = new StringBuilder(32);
+		for (char c = (char) serialized.readUnsignedByte(); c != 0; c = (char) serialized.readUnsignedByte()) {
+			nameBuilder.append(c);
+		}
+		String name = nameBuilder.toString();
+
+		// Read in the number of elements in the path
+		int numElements = serialized.readInt();
+
+		// Read in the left path
+		Trajectory left = new Trajectory(numElements);
+		for (int i = 0; i < numElements; ++i) {
+			left.setSegment(i, loadSegment(serialized));
+		}
+
+		// Read in the right path
+		Trajectory right = new Trajectory(numElements);
+		for (int i = 0; i < numElements; ++i) {
+			right.setSegment(i, loadSegment(serialized));
+		}
+
+		return new Path(name, new Trajectory.Pair(left, right));
+	}
+
+	private Trajectory.Segment loadSegment(DataInputStream serialized) throws IOException {
+		Trajectory.Segment segment = new Trajectory.Segment();
+
+		segment.pos = serialized.readFloat();
+		segment.vel = serialized.readFloat();
+		segment.acc = serialized.readFloat();
+		segment.jerk = serialized.readFloat();
+		segment.heading = serialized.readFloat();
+		segment.dt = serialized.readFloat();
+		segment.x = serialized.readFloat();
+		segment.y = serialized.readFloat();
+
+		return segment;
+	}
+
+}

--- a/src/com/team254/lib/trajectory/io/BinaryDeserializer.java
+++ b/src/com/team254/lib/trajectory/io/BinaryDeserializer.java
@@ -42,14 +42,14 @@ public class BinaryDeserializer {
 	private Trajectory.Segment loadSegment(DataInputStream serialized) throws IOException {
 		Trajectory.Segment segment = new Trajectory.Segment();
 
-		segment.pos = serialized.readFloat();
-		segment.vel = serialized.readFloat();
-		segment.acc = serialized.readFloat();
-		segment.jerk = serialized.readFloat();
-		segment.heading = serialized.readFloat();
-		segment.dt = serialized.readFloat();
-		segment.x = serialized.readFloat();
-		segment.y = serialized.readFloat();
+		segment.pos = serialized.readDouble();
+		segment.vel = serialized.readDouble();
+		segment.acc = serialized.readDouble();
+		segment.jerk = serialized.readDouble();
+		segment.heading = serialized.readDouble();
+		segment.dt = serialized.readDouble();
+		segment.x = serialized.readDouble();
+		segment.y = serialized.readDouble();
 
 		return segment;
 	}

--- a/src/com/team254/lib/trajectory/io/BinarySerializer.java
+++ b/src/com/team254/lib/trajectory/io/BinarySerializer.java
@@ -1,0 +1,44 @@
+package com.team254.lib.trajectory.io;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.team254.lib.trajectory.Path;
+import com.team254.lib.trajectory.Trajectory;
+import com.team254.lib.trajectory.Trajectory.Segment;
+
+/**
+ * Serializes a Path to a binary file.
+ * 
+ * @author mstojcevich
+ */
+public class BinarySerializer {
+
+	public void serialize(DataOutputStream outStream, Path path) throws IOException {
+		// Write the title string, followed by a null terminator
+		outStream.write(path.getName().getBytes());
+		outStream.writeByte(0); // End of string
+
+		// Write all of the segments
+		path.goLeft();
+		outStream.writeInt(path.getLeftWheelTrajectory().getNumSegments());
+		serializeTrajectory(outStream, path.getLeftWheelTrajectory());
+		serializeTrajectory(outStream, path.getRightWheelTrajectory());
+	}
+
+	private void serializeTrajectory(DataOutputStream outStream, Trajectory trajectory) throws IOException {
+		for (int i = 0; i < trajectory.getNumSegments(); ++i) {
+			Segment segment = trajectory.getSegment(i);
+
+			outStream.writeFloat((float) segment.pos);
+			outStream.writeFloat((float) segment.vel);
+			outStream.writeFloat((float) segment.acc);
+			outStream.writeFloat((float) segment.jerk);
+			outStream.writeFloat((float) segment.heading);
+			outStream.writeFloat((float) segment.dt);
+			outStream.writeFloat((float) segment.x);
+			outStream.writeFloat((float) segment.y);
+		}
+	}
+
+}

--- a/src/com/team254/lib/trajectory/io/BinarySerializer.java
+++ b/src/com/team254/lib/trajectory/io/BinarySerializer.java
@@ -30,14 +30,14 @@ public class BinarySerializer {
 		for (int i = 0; i < trajectory.getNumSegments(); ++i) {
 			Segment segment = trajectory.getSegment(i);
 
-			outStream.writeFloat((float) segment.pos);
-			outStream.writeFloat((float) segment.vel);
-			outStream.writeFloat((float) segment.acc);
-			outStream.writeFloat((float) segment.jerk);
-			outStream.writeFloat((float) segment.heading);
-			outStream.writeFloat((float) segment.dt);
-			outStream.writeFloat((float) segment.x);
-			outStream.writeFloat((float) segment.y);
+			outStream.writeDouble(segment.pos);
+			outStream.writeDouble(segment.vel);
+			outStream.writeDouble(segment.acc);
+			outStream.writeDouble(segment.jerk);
+			outStream.writeDouble(segment.heading);
+			outStream.writeDouble(segment.dt);
+			outStream.writeDouble(segment.x);
+			outStream.writeDouble(segment.y);
 		}
 	}
 


### PR DESCRIPTION
This adds a new serializer for cheezy paths. It does not actually switch the current code to use the new serializer.

This is not fully tested for accuracy yet and I would not recommend switching the production code to use this serializer. It should be more accurate (albeit different) than the text serializer, as it serializes all bits of the double as opposed to truncating the decimal representation to three digits after the decimal point.

Benchmarking on my laptop vs the current plaintext serializer, the binary serializer finishes in 3ms while the text serializer finishes in 130ms.

The 130ms is a significant chunk of the total time to generate a path and serialize it. Not sure how significant it will be for the rio, though.

The deserializer is faster too.